### PR TITLE
feat: Implement initial UI and logic for premium user samples

### DIFF
--- a/app/src/main/java/com/example/fromscratch/AppViewModel.kt
+++ b/app/src/main/java/com/example/fromscratch/AppViewModel.kt
@@ -35,6 +35,7 @@ class AppViewModel( // This should be the only declaration of this class in this
         private set
     var showSettingsDialog by mutableStateOf(false)
         private set
+    var showSubscribePopup by mutableStateOf(false) // Added for premium feature popup
 
     // --- Platter and Vinyl Mechanics ---
     var visualPlatterAngle by mutableFloatStateOf(0f)
@@ -151,8 +152,13 @@ class AppViewModel( // This should be the only declaration of this class in this
 
     fun handleButton1Hold() {
         Log.i("AppViewModel_Button1", "handleButton1Hold() CALLED")
-        Log.d("AppViewModel_Button1", "Button 1 Hold: Request User Platter Sample Upload (Placeholder)")
-        // onLoadUserPlatterSample("path/to/user/sample") // Example
+        if (MainActivity.isCurrentUserPremium) {
+            Log.d("AppViewModel_Button1", "Premium user: Triggering user platter sample loading (placeholder).")
+            // onLoadUserPlatterSample("path/to/user/sample") // Example - premium feature
+        } else {
+            Log.d("AppViewModel_Button1", "Non-premium user: Showing subscribe popup.")
+            showSubscribePopup = true
+        }
     }
 
     fun handleButton2Press() {
@@ -186,8 +192,13 @@ class AppViewModel( // This should be the only declaration of this class in this
 
     fun handleButton2Hold() {
         Log.i("AppViewModel_Button2", "handleButton2Hold() CALLED")
-        Log.d("AppViewModel_Button2", "Button 2 Hold: Request User Music Track Upload (Placeholder)")
-        // onLoadUserMusicTrack("path/to/user/track") // Example
+        if (MainActivity.isCurrentUserPremium) {
+            Log.d("AppViewModel_Button2", "Premium user: Triggering user music track loading (placeholder).")
+            // onLoadUserMusicTrack("path/to/user/track") // Example - premium feature
+        } else {
+            Log.d("AppViewModel_Button2", "Non-premium user: Showing subscribe popup.")
+            showSubscribePopup = true
+        }
     }
 
     fun handleHoldBothButtons() {

--- a/app/src/main/java/com/example/fromscratch/MainActivity.kt
+++ b/app/src/main/java/com/example/fromscratch/MainActivity.kt
@@ -13,6 +13,9 @@ import androidx.activity.viewModels
 class MainActivity : ComponentActivity() {
 
     companion object {
+        var isCurrentUserPremium: Boolean = false
+        const val PAYMENT_URL: String = "https://www.example.com/subscribe"
+
         init {
             try {
                 System.loadLibrary("scratch-emulator-lib")

--- a/app/src/test/java/com/example/fromscratch/AppViewModelTest.kt
+++ b/app/src/test/java/com/example/fromscratch/AppViewModelTest.kt
@@ -1,0 +1,83 @@
+package com.example.fromscratch
+
+import org.junit.Test
+import org.junit.Assert.*
+import org.junit.Before
+// No need to import com.example.fromscratch.AppViewModel or MainActivity explicitly if they are in the same package
+// and the test file is correctly placed in the source set that can see them.
+// However, for clarity or if issues arise, explicit imports can be added.
+
+class AppViewModelTest {
+
+    private lateinit var viewModel: AppViewModel
+
+    @Before
+    fun setup() {
+        // Reset static state before each test as it's modified by tests
+        MainActivity.isCurrentUserPremium = false
+
+        viewModel = AppViewModel(
+            onPlayIntroAndLoopOnPlatter = {},
+            onNextPlatterSample = {},
+            onLoadUserPlatterSample = {},
+            onPlayMusicTrack = {},
+            onStopMusicTrack = {},
+            onNextMusicTrackAndPlay = {},
+            onNextMusicTrackAndKeepState = {},
+            onLoadUserMusicTrack = {},
+            onUpdatePlatterFaderVolume = {},
+            onUpdateMusicMasterVolume = {},
+            onScratchPlatterActive = { _, _ -> },
+            onReleasePlatterTouch = {},
+            onUpdateScratchSensitivity = {},
+            onSetAudioNormalizationFactor = {} // This was added in a previous step
+        )
+    }
+
+    @Test
+    fun initialShowSubscribePopup_isFalse() {
+        assertFalse("Initially, showSubscribePopup should be false", viewModel.showSubscribePopup)
+    }
+
+    @Test
+    fun handleButton1Hold_premiumUser_doesNotShowPopup() {
+        MainActivity.isCurrentUserPremium = true
+        viewModel.handleButton1Hold()
+        assertFalse("Popup should NOT show for premium user on Button 1 Hold", viewModel.showSubscribePopup)
+    }
+
+    @Test
+    fun handleButton1Hold_nonPremiumUser_showsPopup() {
+        MainActivity.isCurrentUserPremium = false // Explicitly set, though setup does it too
+        viewModel.handleButton1Hold()
+        assertTrue("Popup SHOULD show for non-premium user on Button 1 Hold", viewModel.showSubscribePopup)
+    }
+
+    @Test
+    fun handleButton2Hold_premiumUser_doesNotShowPopup() {
+        MainActivity.isCurrentUserPremium = true
+        viewModel.handleButton2Hold()
+        assertFalse("Popup should NOT show for premium user on Button 2 Hold", viewModel.showSubscribePopup)
+    }
+
+    @Test
+    fun handleButton2Hold_nonPremiumUser_showsPopup() {
+        MainActivity.isCurrentUserPremium = false // Explicitly set
+        viewModel.handleButton2Hold()
+        assertTrue("Popup SHOULD show for non-premium user on Button 2 Hold", viewModel.showSubscribePopup)
+    }
+
+    @Test
+    fun settingsSwitch_canTogglePremiumStatus() {
+        // Initial state (as set in setup)
+        assertFalse("Initial premium status should be false (from setup)", MainActivity.isCurrentUserPremium)
+
+        // Simulate toggling switch on
+        MainActivity.isCurrentUserPremium = true
+        assertTrue("Premium status should be true after direct modification", MainActivity.isCurrentUserPremium)
+
+        // Simulate toggling switch off
+        MainActivity.isCurrentUserPremium = false
+        assertFalse("Premium status should be false after direct modification back", MainActivity.isCurrentUserPremium)
+    }
+}


### PR DESCRIPTION
This commit introduces the framework for restricting user sample loading to premium users.

Key changes:
- Added a global flag `MainActivity.isCurrentUserPremium` to simulate user premium status.
- Added a "Enable Premium Features (Dev)" switch in the Settings dialog to toggle this flag for testing.
- Modified the 'hold' actions on Button 1 (platter samples) and Button 2 (music tracks):
    - If you are a premium user, a log message indicates that sample loading would proceed (actual file selection and loading are deferred).
    - If you are not a premium user, a "Subscribe to unlock this feature!" popup is displayed.
- The popup includes a "Subscribe" button that (currently) links to a placeholder payment URL and a "Later" button to dismiss.
- Added unit tests for `AppViewModel` to verify:
    - Correct behavior of hold actions based on premium status.
    - Management of the subscribe popup visibility.
    - Toggling of the premium status flag.